### PR TITLE
Better compatibility, better escaping of browser module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ const webpackConfig = {
     rules: [{
       test: /\.css$/,
       use: [
-        'babel-loader', // mini-style-loader returns ES6: Transpile it yourself if you want/need to.
         'mini-style-loader',
         'extract-loader',
         'css-loader'

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function (source) {
     const digestString = loaderUtils.getHashDigest(source, 'sha1', 'base64', 6)
 
     const applyStylePath = path.resolve(__dirname, './lib/apply-style.js')
-    return `module.exports = require('${applyStylePath}')(\`${source}\`, '${digestString}');`
+    return `module.exports = require('${applyStylePath}')(${JSON.stringify(''+source)}, ${JSON.stringify(digestString)});`
   } catch (e) {
     console.error(e)
   }


### PR DESCRIPTION
It looks like you were using backticks to surround the output CSS, which is a nice simple solution but has two drawbacks:

* if the CSS source contains backticks, could badly break things
* using the backticks meant having to `babel-loader` the output

I replaced that with `JSON.stringify` which is still pretty simple but avoids both these issues.

(The digest part didn't really need changing, but I ended up doing the same there mostly just for consistency.)